### PR TITLE
Bump waargonaut

### DIFF
--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,0 +1,7 @@
+{
+  "url": "https://github.com/nixos/nixpkgs-channels.git",
+  "rev": "50f41ea2fcf86def32799f75577a4fe5cfd1132e",
+  "date": "2019-01-20T15:50:29-05:00",
+  "sha256": "1q0bxl5nxx1kabqvyzkdw91c5dnwpi2rwsgs5jdmnj7f0qqgdxh8",
+  "fetchSubmodules": true
+}

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,7 +1,11 @@
-builtins.fetchGit {
-  # Descriptive name to make the store path easier to identify
-  name = "nixos-unstable-2018-10-10";
-  url = https://github.com/nixos/nixpkgs/;
-  # `git ls-remote https://github.com/nixos/nixpkgs-channels nixos-unstable`
-  rev = "0a7e258012b60cbe530a756f09a4f2516786d370";
-}
+let
+  hostNix = import <nixpkgs> {};
+  nixpkgsPin = hostNix.pkgs.lib.importJSON ./nixpkgs.json;
+
+  pinnedPkgs = hostNix.pkgs.fetchFromGitHub {
+    owner = "NixOS";
+    repo  = "nixpkgs-channels";
+    inherit (nixpkgsPin) rev sha256;
+  };
+in
+  pinnedPkgs

--- a/nix/waargonaut.json
+++ b/nix/waargonaut.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/qfpl/waargonaut",
-  "rev": "7bde9dd2d2571c41dffe90197f2a6d7f5ff2193d",
-  "date": "2019-01-08T15:47:54+10:00",
-  "sha256": "0yw4w3ll6ba11gvpkrmxa1n0sldh0nmmpzlqfqszqrrk3l6zksyg",
+  "rev": "24d104b892d56053fa78c33fbb220c55ba41ae8a",
+  "date": "2019-02-04T10:13:01+10:00",
+  "sha256": "1qmvdlfh503v646vmr366kal1srf7hipfajx9sy72mp0niq6xjj8",
   "fetchSubmodules": false
 }

--- a/servant-waargonaut-deps.nix
+++ b/servant-waargonaut-deps.nix
@@ -1,12 +1,16 @@
 self: super:
 let
-  waarg         = import ./nix/waargonaut.nix;
-  waarg-pkg     = import "${waarg}/waargonaut.nix";
-  tasty-wai-pkg = import ./nix/tasty-wai.nix;
+  waarg              = import ./nix/waargonaut.nix;
+  waarg-pkg          = import "${waarg}/waargonaut.nix";
+  tasty-wai-pkg      = import ./nix/tasty-wai.nix;
 in
 {
   haskellPackages = super.haskellPackages.override (old: {
     overrides = self.lib.composeExtensions (old.overrides or (_: _: {})) (hself: hsuper: {
+
+      # 0.3.2.1 tests don't build with generics-sop > 0.4
+      uri-bytestring = self.haskell.lib.dontCheck hsuper.uri-bytestring;
+
       waargonaut = hself.callPackage waarg-pkg {};
       tasty-wai  = hself.callCabal2nix "tasty-wai" tasty-wai-pkg {};
     });

--- a/servant-waargonaut.cabal
+++ b/servant-waargonaut.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                servant-waargonaut
-version:             0.5.0.0
+version:             0.5.0.1
 synopsis:            Servant Integration for Waargonaut JSON Package
 description:         Provides the types and instances necessary to utilise Waargonaut as the JSON handling library for your Servant API.
 -- license:
@@ -37,8 +37,8 @@ library
   -- other-modules:
   -- other-extensions:
   build-depends:       base        >= 4.11   && < 4.13
-                     , servant     >= 0.14.1 && < 0.15
-                     , waargonaut  == 0.5.*
+                     , servant     >= 0.14.1 && < 0.16
+                     , waargonaut  >= 0.5.2.2 && < 0.6
                      , attoparsec
                      , bytestring
                      , text

--- a/servant-waargonaut.cabal
+++ b/servant-waargonaut.cabal
@@ -38,7 +38,7 @@ library
   -- other-extensions:
   build-depends:       base        >= 4.11   && < 4.13
                      , servant     >= 0.14.1 && < 0.16
-                     , waargonaut  >= 0.5.2.2 && < 0.6
+                     , waargonaut  >= 0.5    && < 0.6
                      , attoparsec
                      , bytestring
                      , text

--- a/servant-waargonaut.nix
+++ b/servant-waargonaut.nix
@@ -5,7 +5,7 @@
 }:
 mkDerivation {
   pname = "servant-waargonaut";
-  version = "0.5.0.0";
+  version = "0.5.0.1";
   src = ./.;
   libraryHaskellDepends = [
     attoparsec base bytestring http-media lens servant text waargonaut


### PR DESCRIPTION
Fixes #6 

Loosens upper bound on `servant`.
Nix overlay disables tests on `uri-bytestring` due to bug in tests with `generics-sop`. Fixed in `0.3.2.2` but that's not on hackage yet and we don't have to build tests for now anyway.