### PR TITLE
Upgrade to latest Waargonaut.

### DIFF
--- a/nix/waargonaut.json
+++ b/nix/waargonaut.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/qfpl/waargonaut",
-  "rev": "24d104b892d56053fa78c33fbb220c55ba41ae8a",
-  "date": "2019-02-04T10:13:01+10:00",
-  "sha256": "1qmvdlfh503v646vmr366kal1srf7hipfajx9sy72mp0niq6xjj8",
+  "rev": "80e6c283d31ad4c01f1338b0bd1a9ca7526dc1a4",
+  "date": "2019-02-27T15:39:47+10:00",
+  "sha256": "1j1jj1m2qpqy7955r1pzgja6w7n3kipqc1ylzqpsvji64r63lxhs",
   "fetchSubmodules": false
 }

--- a/servant-waargonaut.cabal
+++ b/servant-waargonaut.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                servant-waargonaut
-version:             0.5.0.1
+version:             0.6.0.0
 synopsis:            Servant Integration for Waargonaut JSON Package
 description:         Provides the types and instances necessary to utilise Waargonaut as the JSON handling library for your Servant API.
 -- license:

--- a/servant-waargonaut.cabal
+++ b/servant-waargonaut.cabal
@@ -43,8 +43,7 @@ library
   -- other-extensions:
   build-depends:       base                >= 4.9    && < 4.13
                      , servant             >= 0.14.1 && < 0.16
-                     , waargonaut          >= 0.5    && < 0.6
-                     , attoparsec          >= 0.13.2 && < 0.14
+                     , waargonaut          >= 0.6    && < 0.7
                      , bytestring          >= 0.10.8 && < 0.11
                      , text                >= 1.2.3  && < 1.3
                      , http-media          >= 0.7.1  && < 0.8
@@ -71,9 +70,8 @@ test-suite saarg
                      , servant-waargonaut
                      , servant-server
                      , servant             >= 0.14.1 && < 0.16
-                     , waargonaut          >= 0.5    && < 0.6
+                     , waargonaut          >= 0.6    && < 0.7
 
-                     , attoparsec          >= 0.13.2 && < 0.14
                      , bytestring          >= 0.10.8 && < 0.11
                      , text                >= 1.2.3  && < 1.3
                      , http-media          >= 0.7.1  && < 0.8

--- a/servant-waargonaut.nix
+++ b/servant-waargonaut.nix
@@ -1,19 +1,19 @@
-{ mkDerivation, attoparsec, base, bytestring, http-media
-, http-types, lens, servant, servant-server, stdenv, tasty
-, tasty-wai, text, transformers, waargonaut, wai
-, wl-pprint-annotated
+{ mkDerivation, base, bytestring, http-media, http-types, lens
+, servant, servant-server, stdenv, tasty, tasty-wai, text
+, transformers, waargonaut, wai, wl-pprint-annotated
 }:
 mkDerivation {
   pname = "servant-waargonaut";
-  version = "0.5.0.1";
+  version = "0.6.0.0";
   src = ./.;
   libraryHaskellDepends = [
-    attoparsec base bytestring http-media lens servant text waargonaut
+    base bytestring http-media lens servant text waargonaut
     wl-pprint-annotated
   ];
   testHaskellDepends = [
-    base bytestring http-types servant servant-server tasty tasty-wai
-    text transformers waargonaut wai
+    base bytestring http-media http-types lens servant servant-server
+    tasty tasty-wai text transformers waargonaut wai
+    wl-pprint-annotated
   ];
   description = "Servant Integration for Waargonaut JSON Package";
   license = stdenv.lib.licenses.bsd3;

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -27,7 +27,7 @@ main = defaultMain $ testGroup "Servant Waargonaut"
       assertBody (BSL.fromStrict testPersonBS) res
 
   , testWai app "POST '/' - 200 and accepts a Waarg Decoded Person" $ do
-      let bdy = W.simplePureEncodeNoSpaces (W.proxy W.mkEncoder (Proxy :: Proxy TestAARG)) testPerson
+      let bdy = W.simplePureEncodeTextNoSpaces (W.proxy W.mkEncoder (Proxy :: Proxy TestAARG)) testPerson
 
       res <- srequest $ buildRequestWithHeaders POST "/"
              (TextLE.encodeUtf8 bdy)


### PR DESCRIPTION
Fixes #9

Make the changes to use the latest Waargonaut, including using the default parser module that uses attoparsec.

Drop the explicit attoparsec dep.

Update tests